### PR TITLE
Fix postgres error in build_occurrences rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Schedulable allows for persisting occurrences and associate them with your model
 Your occurrence model must include an attribute of type 'datetime' with name 'date' as well as a reference to your event model to setup up the association properly:  
 
 ```ruby
-rails g model EventOccurrence event_id:integer date:datetime
+rails g schedulable:occurrence EventOccurrence
 ```
 
 ```ruby

--- a/lib/generators/schedulable/templates/migrations/create_occurrences.erb
+++ b/lib/generators/schedulable/templates/migrations/create_occurrences.erb
@@ -1,4 +1,4 @@
-class Create<%= name.pluralize %> < ActiveRecord::Migration
+class Create<%= name.classify.pluralize %> < ActiveRecord::Migration
   def self.up
     create_table :<%= name.tableize %> do |t|
 <% attributes.each do |attribute| %>

--- a/lib/generators/schedulable/templates/models/occurrence.erb
+++ b/lib/generators/schedulable/templates/models/occurrence.erb
@@ -1,6 +1,6 @@
 class <%= name.classify %> < ActiveRecord::Base
   belongs_to :schedulable, polymorphic: true
-  default_scope :order => 'date ASC'
+  default_scope lambda{order('date ASC')}
   scope :remaining, lambda{where(["date >= ?",Time.now])}
   scope :previous, lambda{where(["date < ?",Time.now])}
 end

--- a/lib/generators/schedulable/templates/models/occurrence.erb
+++ b/lib/generators/schedulable/templates/models/occurrence.erb
@@ -1,4 +1,4 @@
-class <%= name %> < ActiveRecord::Base
+class <%= name.classify %> < ActiveRecord::Base
   belongs_to :schedulable, polymorphic: true
   default_scope :order => 'date ASC'
   scope :remaining, lambda{where(["date >= ?",Time.now])}

--- a/lib/tasks/schedulable_tasks.rake
+++ b/lib/tasks/schedulable_tasks.rake
@@ -2,8 +2,8 @@ require 'rake'
 desc 'Builds occurrences for schedulable models'
 namespace :schedulable do
   task :build_occurrences => :environment do
-    Schedule.uniq.pluck(:schedulable_type).each do |schedule|
-      clazz = schedule.schedulable.class
+    Schedule.uniq.pluck(:schedulable_type).each do |schedulable_type|
+      clazz = schedulable_type.constantize
       occurrences_associations = Schedulable::ActsAsSchedulable.occurrences_associations_for(clazz)
       occurrences_associations.each do |association|
         clazz.send("build_" + association.to_s)

--- a/lib/tasks/schedulable_tasks.rake
+++ b/lib/tasks/schedulable_tasks.rake
@@ -2,7 +2,7 @@ require 'rake'
 desc 'Builds occurrences for schedulable models'
 namespace :schedulable do
   task :build_occurrences => :environment do
-    Schedule.group(:schedulable_type).each do |schedule|
+    Schedule.uniq.pluck(:schedulable_type).each do |schedule|
       clazz = schedule.schedulable.class
       occurrences_associations = Schedulable::ActsAsSchedulable.occurrences_associations_for(clazz)
       occurrences_associations.each do |association|


### PR DESCRIPTION
This line
```
Schedule.group(:schedulable_type).each do |schedule|
```
causes the following error in postgres:
```
ActiveRecord::StatementInvalid: PG::GroupingError: ERROR:  column "schedules.id" must appear in the GROUP BY clause or be used in an aggregate function
```

Fixed that.  Also fixed an error I was getting from deprecated default_scope syntax in the occurrence model generator, added support for passing model name in either camel or snake case, and added a reference to that generator to the readme.