### PR TITLE
Use a symbol as a string to define callback

### DIFF
--- a/lib/schedulable/acts_as_schedulable.rb
+++ b/lib/schedulable/acts_as_schedulable.rb
@@ -49,7 +49,7 @@ module Schedulable
           
           ActsAsSchedulable.add_occurrences_association(self, occurrences_association)
           
-          after_save "build_#{occurrences_association}"
+          after_save :"build_#{occurrences_association}"
  
           self.class.instance_eval do
             define_method("build_#{occurrences_association}") do 


### PR DESCRIPTION
Make compatible with Rails 5.1
http://edgeguides.rubyonrails.org/5_1_release_notes.html#active-support-deprecations